### PR TITLE
Fixes done for record button bug

### DIFF
--- a/packages/ui-components/src/Recorder/RecorderControls.jsx
+++ b/packages/ui-components/src/Recorder/RecorderControls.jsx
@@ -50,14 +50,14 @@ const RecorderControls = props => {
     dispatch({
       type: "RECORD_ON"
     });
-    onStartRecorder;
+    onStartRecorder();
   };
 
   const handleClick_RecordOff = () => {
     dispatch({
       type: "RECORD_OFF"
     });
-    onStopRecorder;
+    onStopRecorder();
   };
 
   return (


### PR DESCRIPTION
Fixes #13 

**Describe the changes proposed**
The root cause is simply with a wrong expression used for callback/event bubbling , in `RecorderControls` component. 
The second change (see below) is directly related to this bug, but it will manifest in a similar defect with the `Stop` button. Fixed preemptively.
- From within `handleClick_RecordOn` function, `onStartRecorder` must evaluate to a function (i.e. written as `onStartRecorder()`
- From within `handleClick_RecordOff` function, `onStopRecorder` must evaluate to a function (i.e. written as `onStopRecorder()`

**User Guide**
No new behavior introduced

**Expected behavior**
User does see the allow screen share and select screen prompt

**Screenshots**
![image](https://user-images.githubusercontent.com/60540758/79416997-95b6d800-7fce-11ea-9894-586b8d9a27b2.png)

**Additional context**
None.

@soumik-mukherjee