### PR TITLE
Bugfix: Added yarn build and serve scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,28 @@ The `component library` comes bundled with [storybook](https://storybook.js.org/
 
 To run the `storybook` server, execute from the repo root dir
 
-> yarn run:ui-stories
+```bash
+$ yarn run:ui-stories
+```
 
-To run the `gatsby` app, execute from the repo root dir
+To run a `development` server with the `gatsby` app, execute from the repo root dir
 
-> yarn develop:webapp
+```bash
+$ yarn develop:webapp
+```
+
+To build the `gatsby` web app, i.e. `production` build (this creates the html, css and js bundles in the `packages/webapp/public` folder), execute from the repo root dir
+
+```bash
+$ yarn build:webapp
+```
+
+You can also run a local server to check out your `production` build, with
+
+```bash
+$ yarn serve:webapp
+```
+
 
 ### Submitting PRs
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "scripts": {
     "develop:webapp": "yarn workspace @project/webapp develop",
     "clean:webapp": "yarn workspace @project/webapp clean",
-    "run:ui-stories": "yarn workspace @project/ui-components storybook"
+    "run:ui-stories": "yarn workspace @project/ui-components storybook",
+    "build:webapp": "yarn workspace @project/webapp build",
+    "serve:webapp": "yarn workspace @project/webapp serve"
   },
   "devDependencies": {
     "lerna": "^3.20.2"


### PR DESCRIPTION
Fixes #27 

**Describe the changes proposed**
Commit 650c7183c8a1573dfed31b48d5b2c7a8b2d534f5 includes changes to the repo level `package.json`. The following changes were done,

- A `build:webapp` script to produce a `production` build in the `public` folder
- A `serve:webapp` script to host the `production` build in a local server

Also, the repo readme was updated to include new commands

**User Guide**

To build the `gatsby` web app, i.e. `production` build (this creates the html, css and js bundles in the `packages/webapp/public` folder), execute from the repo root dir

```bash
$ yarn build:webapp
```

You can also run a local server to check out your `production` build, with

```bash
$ yarn serve:webapp
```

**Expected behavior**
NA

**Screenshots**
NA

**Additional context**
NA

@soumik-mukherjee